### PR TITLE
Attempts to fix `/docs` 404 flash.

### DIFF
--- a/packages/docs/vercel.json
+++ b/packages/docs/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
There's a brief flash of a 404 on the `/docs` site. 

![CleanShot 2022-11-10 at 09 17 44](https://user-images.githubusercontent.com/446260/201145200-de83c820-adfd-429c-b987-200934cf574d.gif)

After doing some digging, I'd like to try [this solution](https://stackoverflow.com/a/74144396/808823) to see if it goes away.

Fair warning... This may or may not work, but I'll clean up after myself if it doesn't. 😊 

If you allow this to deploy to a Vercel preview url, we should be able to test it before merging to ensure it works.